### PR TITLE
Add option to use custom Azure Storage endpoint

### DIFF
--- a/packages/azure/src/AzureBlobStorage.ts
+++ b/packages/azure/src/AzureBlobStorage.ts
@@ -18,7 +18,7 @@ export class AzureBlobStorage extends Storage<AzureBlobStorageOptions> {
       options.accountKey
     )
     this.blobClient = new BlobServiceClient(
-      `https://${options.accountName}.blob.core.windows.net`,
+      options.endpoint || `https://${options.accountName}.blob.core.windows.net`,
       credentials
     )
     this.containerClient = this.blobClient.getContainerClient(options.container)

--- a/packages/azure/src/AzureBlobStorageOptions.ts
+++ b/packages/azure/src/AzureBlobStorageOptions.ts
@@ -4,4 +4,5 @@ export interface AzureBlobStorageOptions extends StorageOptions {
   container: string
   accountName: string
   accountKey: string
+  endpoint?: string
 }


### PR DESCRIPTION
Currently storage-azure hard-codes the endpoint of the Azure Storage
account to `blob.core.windows.net` which means that the library can't be
used in regions such as Azure China or Azure Government, with Azure
Stack, or with the Storage Emulator for testing.

This change enables customizing the storage endpoint to remove this
limitation. With this change, we can for example use storage-azure to
talk to the Azurite storage emulator [1] like so:

```ts
const az = new AzureBlobStorage({
  container: process.env.CONTAINER,
  accountName: 'devstoreaccount1',
  accountKey: 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==',
  endpoint: 'http://localhost:10000'
})
await az.writeFile('azure-write/test.txt', 'using azure storage emulator')
```

[1] https://github.com/Azure/Azurite